### PR TITLE
Update unit testing dependencies

### DIFF
--- a/buildSrc/src/main/kotlin/Deps.kt
+++ b/buildSrc/src/main/kotlin/Deps.kt
@@ -84,10 +84,10 @@ object Deps {
 
   const val coil = "io.coil-kt:coil:0.11.0"
 
-  const val mockk = "io.mockk:mockk:1.10.0"
+  const val mockk = "io.mockk:mockk:1.10.2"
 
   object kotest {
-    private const val version = "4.0.5"
+    private const val version = "4.2.5"
     const val framework = "io.kotest:kotest-runner-junit5-jvm:$version"
     const val assertions = "io.kotest:kotest-assertions-core-jvm:$version"
   }

--- a/domain/src/test/kotlin/download/service/DownloaderTest.kt
+++ b/domain/src/test/kotlin/download/service/DownloaderTest.kt
@@ -8,7 +8,7 @@
 
 package tachiyomi.domain.download.service
 
-import io.kotest.core.spec.TestConfiguration
+import io.kotest.core.TestConfiguration
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.test.TestContext
 import io.kotest.matchers.shouldBe


### PR DESCRIPTION
Unit tests broke after updating to Kotlin 1.4.x, so this is meant to fix that.

1 tests currently fail, but I have no idea why:

```
restores backup chapters when they're more recent (db chapter present)
restores backup chapters when they're more recent (db chapter missing)
```

Example error:

```
Verification failed: calls are not in verification order
java.lang.AssertionError: Verification failed: calls are not in verification order

Matchers: 
+ChapterRepository(#3).delete(matcher<List>(), any()))
ChapterRepository(#3).insert(eq([]), any()))

Calls:
1) ChapterRepository(#3).findForManga(0, continuation {})
2) +ChapterRepository(#3).delete([Chapter(id=0, mangaId=1, key=chkey1, name=name 1, read=false, bookmark=false, progress=0, dateUpload=0, dateFetch=0, sourceOrder=0, number=0.0, scanlator=)], continuation {})
3) ChapterRepository(#3).insert([Chapter(id=0, mangaId=0, key=chkey1, name=name 1, read=false, bookmark=false, progress=0, dateUpload=0, dateFetch=0, sourceOrder=0, number=0.0, scanlator=)], continuation {})
```